### PR TITLE
Fix push CI workflows

### DIFF
--- a/.github/workflows/code_changes.yaml
+++ b/.github/workflows/code_changes.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Build documentation
         run: |
           cd docs
-          jupyter-book build . --all
+          jupyter-book build .
       
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,10 +1,4 @@
 - bump: patch
   changes:
-    added:
-    - CI/CD infrastructure with GitHub Actions
-    - Automatic changelog management with yaml-changelog
-    - PyPI publishing workflow
-    - Code formatting checks with Black
-    - Multi-platform and multi-Python version testing
-    - Jupyter Book documentation setup
-    - Comprehensive Makefile for development tasks
+    fixed:
+    - Fixed push CI workflows for documentation build and versioning


### PR DESCRIPTION
## Summary
This PR fixes the CI workflows that failed after merging PR #1.

## Changes
- Remove `--all` flag from `jupyter-book build` command in code_changes.yaml (only valid for JB 2.0)
- Add changelog entry for version bump

## Testing
- CI should pass on this PR
- Push workflows should work correctly after merge