### PR TITLE
Fix yaml-changelog invocation in versioning workflow

### DIFF
--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -29,8 +29,8 @@ jobs:
       
       - name: Install yaml-changelog and build tools
         run: |
-          pip install --upgrade pip
-          pip install yaml-changelog build setuptools wheel
+          python -m pip install --upgrade pip
+          python -m pip install yaml-changelog build setuptools wheel
       
       - name: Check for changelog entry
         id: check_changelog
@@ -46,7 +46,7 @@ jobs:
         id: version
         run: |
           # Update changelog
-          yaml-changelog . --release
+          python -m yaml_changelog --release
           
           # Get new version
           NEW_VERSION=$(python -c "import re; content=open('changelog.yaml').read(); match=re.search(r'version: ([\d.]+)', content); print(match.group(1) if match else '0.1.0')")

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,8 +1,4 @@
 - bump: patch
   changes:
     fixed:
-    - Fixed yaml-changelog command to use python -m syntax
-    - Fixed documentation build by adding [documentation] extra without rpy2 dependency
-    - Updated all workflows to use Python 3.13
-    added:
-    - Added documentation build test to PR CI to catch issues before merge
+    - Fixed yaml-changelog command invocation in versioning workflow using python -m


### PR DESCRIPTION
## Summary
Fixes the versioning workflow that's failing in push CI.

## Changes
- Use `python -m yaml_changelog` instead of `yaml-changelog` command
- Use `python -m pip` for consistent installation

## Testing
- PR CI should pass
- After merge, versioning workflow should successfully publish to PyPI