### PR TITLE
Use correct build-changelog command

### DIFF
--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -46,7 +46,7 @@ jobs:
         id: version
         run: |
           # Update changelog
-          python -m yaml_changelog --release
+          build-changelog changelog.yaml --release
           
           # Get new version
           NEW_VERSION=$(python -c "import re; content=open('changelog.yaml').read(); match=re.search(r'version: ([\d.]+)', content); print(match.group(1) if match else '0.1.0')")

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     fixed:
-    - Fixed yaml-changelog command invocation in versioning workflow using python -m
+    - Use correct yaml-changelog command (build-changelog) in versioning workflow


### PR DESCRIPTION
## Summary
Final fix for the versioning workflow - use the correct command name.

## Issue
`yaml-changelog` package installs commands as `build-changelog` and `bump-version`, not `yaml-changelog`.

## Changes
- Use `build-changelog` command instead of `python -m yaml_changelog`

## Testing
- PR CI should pass
- After merge, versioning workflow should successfully publish to PyPI