### PR TITLE
Fix build-changelog command syntax in versioning workflow

### DIFF
--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -46,7 +46,7 @@ jobs:
         id: version
         run: |
           # Update changelog
-          build-changelog changelog.yaml --release
+          build-changelog changelog.yaml --output changelog.yaml --append-file changelog_entry.yaml --update-last-date
           
           # Get new version
           NEW_VERSION=$(python -c "import re; content=open('changelog.yaml').read(); match=re.search(r'version: ([\d.]+)', content); print(match.group(1) if match else '0.1.0')")

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     fixed:
-    - Use correct yaml-changelog command (build-changelog) in versioning workflow
+    - Correct build-changelog syntax in versioning workflow with proper arguments


### PR DESCRIPTION
This PR fixes the build-changelog command in the versioning workflow to use the correct syntax with explicit --output and --append-file arguments.

The previous syntax was based on assumptions about a --release flag that doesn't exist in the current yaml-changelog implementation.

Changes:
- Use explicit --output, --append-file, and --update-last-date arguments
- This should resolve the versioning workflow failures

Related to the yaml-changelog issues filed:
- PolicyEngine/yaml-changelog#18 (requesting --release flag)
- PolicyEngine/yaml-changelog#19 (better error handling)