### PR TITLE
Fix PyPI publishing permissions for trusted publishers

### DIFF
--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Add id-token permission for PyPI publishing with trusted publishers


### PR DESCRIPTION
This PR adds the required `id-token: write` permission to the versioning workflow to enable PyPI publishing with trusted publishers (OIDC).

The previous push CI failed with:
> OpenID Connect token retrieval failed: GitHub: missing or insufficient OIDC token permissions

This is required for the PyPA's trusted publisher feature which is more secure than using API tokens.