### PR TITLE
Add manual PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish-manual.yaml
+++ b/.github/workflows/publish-manual.yaml
@@ -1,0 +1,37 @@
+name: Publish to PyPI (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to publish (e.g., v0.1.0)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build setuptools wheel
+      
+      - name: Build package
+        run: python -m build
+      
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
-    fixed:
-    - Add id-token permission for PyPI publishing with trusted publishers
+    added:
+    - Manual PyPI publishing workflow for recovering from failed automated publishes


### PR DESCRIPTION
This PR adds a manual workflow dispatch action to publish to PyPI. This is useful for:

1. Recovering from failed automated publishes (like our current v0.1.0 situation)
2. Manually re-publishing if needed
3. Testing publishing without going through the full versioning workflow

The workflow:
- Takes a git tag as input
- Checks out that specific tag
- Builds the package
- Publishes to PyPI with trusted publisher (OIDC) authentication
- Skips existing versions to avoid conflicts