### PR TITLE
Add flexible PyPI publishing with token support

### DIFF
--- a/.github/workflows/publish-manual.yaml
+++ b/.github/workflows/publish-manual.yaml
@@ -31,7 +31,15 @@ jobs:
       - name: Build package
         run: python -m build
       
-      - name: Publish to PyPI
+      - name: Publish to PyPI (Token)
+        if: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true
+      
+      - name: Publish to PyPI (OIDC)
+        if: ${{ !secrets.PYPI_API_TOKEN }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true

--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -83,8 +83,17 @@ jobs:
         run: python -m build
       
       - name: Publish to PyPI
+        id: publish
         if: steps.check_changelog.outputs.has_changelog == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
+        continue-on-error: true
+      
+      - name: Report PyPI publishing status
+        if: steps.check_changelog.outputs.has_changelog == 'true'
+        run: |
+          if [ "${{ steps.publish.outcome }}" == "failure" ]; then
+            echo "::warning::PyPI publishing failed. Please check if PYPI_API_TOKEN secret is configured or manually publish using the 'Publish to PyPI (Manual)' workflow."
+          fi

--- a/README.md
+++ b/README.md
@@ -154,6 +154,37 @@ If you use this package in your research, please cite both this package and the 
 
 Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
 
+### PyPI Publishing Setup
+
+This repository uses GitHub Actions for automated PyPI publishing. To enable publishing:
+
+#### Option 1: PyPI API Token (Recommended for now)
+1. Create an account on [PyPI](https://pypi.org/) if you don't have one
+2. Generate an API token:
+   - Go to your PyPI account settings
+   - Scroll to "API tokens" section
+   - Click "Add API token"
+   - Give it a meaningful name (e.g., "py-statmatch GitHub Actions")
+   - Select scope: "Entire account" (for first publish) or "Project: py-statmatch" (after first publish)
+3. Add the token as a GitHub repository secret:
+   - Go to Settings → Secrets and variables → Actions
+   - Click "New repository secret"
+   - Name: `PYPI_API_TOKEN`
+   - Value: Your PyPI API token (starts with `pypi-`)
+
+#### Option 2: Trusted Publisher (OIDC) - Future Enhancement
+1. First manually publish the package once using Option 1
+2. Go to your PyPI project page
+3. Navigate to "Publishing" settings
+4. Add GitHub as a trusted publisher:
+   - Owner: `PolicyEngine`
+   - Repository: `py-statmatch`
+   - Workflow: `versioning.yaml`
+   - Environment: (leave blank)
+5. Remove the PYPI_API_TOKEN secret (optional)
+
+The workflows automatically detect which method to use based on available secrets.
+
 ## Acknowledgments
 
 This is a Python port of the R StatMatch package by Marcello D'Orazio. We are grateful for the original implementation which has been invaluable to the statistical matching community.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,8 @@
 - bump: patch
   changes:
     added:
-    - Manual PyPI publishing workflow for recovering from failed automated publishes
+    - Support for both PyPI API token and OIDC trusted publisher authentication
+    - Instructions for PyPI publishing setup in README
+    improved:
+    - Workflows now gracefully handle missing PyPI credentials with helpful warnings
+    - Manual publish workflow tries token auth first, falls back to OIDC


### PR DESCRIPTION
This PR improves PyPI publishing to support both authentication methods:

## Changes

1. **Modified versioning workflow**:
   - Added `continue-on-error: true` to PyPI publish step
   - Added warning message when publishing fails
   - Directs users to use manual workflow or configure PYPI_API_TOKEN

2. **Enhanced manual publish workflow**:
   - Tries API token first if available
   - Falls back to OIDC (trusted publisher) if no token
   - Better handles both authentication methods

3. **Updated README**:
   - Added comprehensive PyPI setup instructions
   - Explains both API token (current) and trusted publisher (future) options
   - Step-by-step guide for repository maintainers

## Benefits

- No more hard failures in CI when PyPI isn't configured
- Clear instructions for maintainers to enable publishing
- Supports gradual migration from tokens to trusted publishers
- Helpful error messages guide users to the solution

## Next Steps

Repository owner should:
1. Create a PyPI account
2. Generate an API token
3. Add it as PYPI_API_TOKEN secret
4. Use manual workflow to publish v0.1.0