### PR TITLE
Fix package discovery for git installs

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Package discovery for git installs (explicit setuptools include of statmatch*)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,8 @@ testpaths = ["tests"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
+[tool.setuptools.packages.find]
+# The repo is flat-layout with several non-package top-level directories
+# (website/, r-statmatch-src/, scripts/); without an explicit include,
+# setuptools' automatic discovery refuses to build from a git dependency.
+include = ["statmatch*"]


### PR DESCRIPTION
Setuptools automatic discovery fails on the flat layout (`website/`, `r-statmatch-src/`, `scripts/` are seen as candidate top-level packages), so `pip install git+...` / uv git dependencies cannot build the package. An explicit `[tool.setuptools.packages.find] include = ["statmatch*"]` restores buildability without changing the distributed contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)